### PR TITLE
Fix puck.js isBusy typo

### DIFF
--- a/js/puck.js
+++ b/js/puck.js
@@ -215,7 +215,7 @@ var Puck = (function() {
       connection.txInProgress = false;
       connection.isOpen = true;
       connection.isOpening = false;
-      isbusy = false;
+      isBusy = false;
       queue = [];
       callback(connection);
       connection.emit('open');


### PR DESCRIPTION
Yo!  This was throwing an error when I was running the script in strict mode (as a es module).

Guess it might have had an effect on reconnecting too?